### PR TITLE
vendor: Properly handle Magisk Hide feature.

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -241,6 +241,10 @@ PRODUCT_PRODUCT_PROPERTIES += \
     setupwizard.feature.show_pai_screen_in_main_flow.carrier1839=false \
     setupwizard.feature.show_pixel_tos=false
 
+# Magisk Hide
+PRODUCT_COPY_FILES += \
+    vendor/komodo/prebuilt/system/etc/init.komodo.rc:system/etc/init/init.komodo.rc
+
 # Themed bootanimation
 TARGET_MISC_BLOCK_OFFSET ?= 0
 PRODUCT_SYSTEM_DEFAULT_PROPERTIES += \

--- a/prebuilt/system/etc/init.komodo.rc
+++ b/prebuilt/system/etc/init.komodo.rc
@@ -1,0 +1,4 @@
+on property:sys.boot_completed=1
+    # Restrict permissions to socket file
+    # to hide Magisk & co.
+    chmod 440 /proc/net/unix


### PR DESCRIPTION
Some banking apps read the file /proc/net/unix to
find out whether things like Magisk are installed/running.

To prevent that, chmod it 440.
This file isn't needed by any other process when boot is finished.